### PR TITLE
Fix/db reconnect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,14 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Provided within Spigot -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.32</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ru/soknight/peconomy/PEconomy.java
+++ b/src/main/java/ru/soknight/peconomy/PEconomy.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
-import ru.soknight.lib.configuration.Configuration;
 import ru.soknight.lib.configuration.LocalizableMessages;
 import ru.soknight.lib.configuration.Messages;
 import ru.soknight.lib.configuration.locale.examiner.LocaleTagExaminer;
@@ -19,6 +18,7 @@ import ru.soknight.peconomy.command.CommandBalance;
 import ru.soknight.peconomy.command.CommandPay;
 import ru.soknight.peconomy.command.CommandPeconomy;
 import ru.soknight.peconomy.configuration.CurrenciesManager;
+import ru.soknight.peconomy.configuration.HookingConfiguration;
 import ru.soknight.peconomy.database.DatabaseManager;
 import ru.soknight.peconomy.database.model.TransactionModel;
 import ru.soknight.peconomy.database.model.WalletModel;
@@ -44,7 +44,7 @@ public final class PEconomy extends JavaPlugin {
 
     private static PEconomyAPI apiInstance;
     
-    private Configuration config;
+    private HookingConfiguration config;
     private Messages messages;
     
     private DatabaseManager databaseManager;
@@ -164,7 +164,7 @@ public final class PEconomy extends JavaPlugin {
     }
     
     private void loadConfigurations() {
-        this.config = new Configuration(this, "config.yml");
+        this.config = new HookingConfiguration(this, "config.yml");
         this.config.refresh();
 
         this.messages = new LocalizableMessages(this)

--- a/src/main/java/ru/soknight/peconomy/configuration/HookingConfiguration.java
+++ b/src/main/java/ru/soknight/peconomy/configuration/HookingConfiguration.java
@@ -1,0 +1,38 @@
+package ru.soknight.peconomy.configuration;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import ru.soknight.lib.configuration.Configuration;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+
+/**
+ *  A {@link Configuration} that makes it possible to subscribe to
+ * configuration updates throughout the plugin's life-cycle.
+ */
+public final class HookingConfiguration extends Configuration {
+    private final Collection<Consumer<Configuration>> onRefreshedListeners;
+
+    public HookingConfiguration(final @NotNull JavaPlugin plugin, final @NotNull String fileName) {
+        super(plugin, fileName);
+        onRefreshedListeners = new ConcurrentLinkedQueue<>(); /* preserve order and keep it thread-safe */
+    }
+
+    /**
+     *  The given listener will be called when this configuration
+     * object gets fully refreshed.
+     *
+     * @see #refresh()
+     */
+    public void subscribeOnRefreshed(final @NotNull Consumer<Configuration> listener) {
+        onRefreshedListeners.add(listener);
+    }
+
+    @Override public void refresh() {
+        super.refresh();
+        for (final Consumer<Configuration> listener : onRefreshedListeners)
+            listener.accept(this);
+    }
+}

--- a/src/main/java/ru/soknight/peconomy/configuration/IntervalsQueue.java
+++ b/src/main/java/ru/soknight/peconomy/configuration/IntervalsQueue.java
@@ -1,0 +1,51 @@
+package ru.soknight.peconomy.configuration;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class IntervalsQueue {
+    private final Queue<Long> intervals = new ConcurrentLinkedQueue<>();
+    private final AtomicLong lastRetrieved = new AtomicLong(-1);
+    private TimeUnit unit = TimeUnit.SECONDS;
+
+    /**
+     *  Retrieves a next interval from this queue, removing queue's head,
+     * or returns the last one if there's no intervals left.
+     *
+     * @return a next interval if able to pop, the last interval retrieved if
+     *          preset or a negative number if there were no retrievals yet.
+     */
+    public long nextOrLast() {
+        final Long nextInterval = intervals.poll();
+        if (nextInterval != null) {
+            lastRetrieved.set(nextInterval);
+            return nextInterval;
+        }
+        return lastRetrieved.get();
+    }
+
+    /** Gets a {@link TimeUnit} for all intervals within this queue. */
+    public @NotNull TimeUnit intervalTimeUnit() {
+        return unit;
+    }
+
+    public void resetIntervals(final @NotNull List<Long> intervals) {
+        resetIntervals(intervals, unit);
+    }
+
+    public synchronized void resetIntervals(final @NotNull List<Long> intervals, final @NotNull TimeUnit unit) {
+        this.intervals.clear();
+        if (intervals.isEmpty()) {
+            lastRetrieved.set(-1);
+            return;
+        }
+        this.intervals.addAll(intervals);
+        this.unit = unit;
+    }
+}
+

--- a/src/main/java/ru/soknight/peconomy/database/ReconnectingThrowableHandler.java
+++ b/src/main/java/ru/soknight/peconomy/database/ReconnectingThrowableHandler.java
@@ -1,0 +1,84 @@
+package ru.soknight.peconomy.database;
+
+import com.mysql.cj.jdbc.exceptions.CommunicationsException;
+import org.jetbrains.annotations.NotNull;
+import ru.soknight.lib.configuration.Configuration;
+import ru.soknight.lib.executable.quiet.ThrowableHandler;
+import ru.soknight.peconomy.configuration.HookingConfiguration;
+import ru.soknight.peconomy.configuration.IntervalsQueue;
+import ru.soknight.peconomy.task.BukkitTaskScheduler;
+import ru.soknight.peconomy.task.ReconnectTask;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import static java.text.MessageFormat.format;
+
+/**
+ *  Initiates database reconnection if detects a communications
+ * link failure or a closed connection.
+ */
+public final class ReconnectingThrowableHandler implements ThrowableHandler {
+    public static final String DO_RECONNECT_PATH = "database.reconnect.auto";
+    public static final boolean DO_RECONNECT_DEFAULT = false;
+    public static final String RECONNECTION_INTERVALS_PATH = "database.reconnect.intervals-in-seconds";
+    public static final TimeUnit DEFAULT_INTERVALS_TIME_UNIT = TimeUnit.SECONDS;
+
+    private final Supplier<Boolean> isEnabledSupplier;
+    private final IntervalsQueue intervalsQueue = new IntervalsQueue();
+    private final ReconnectTask reconnectTask;
+    private final Logger log;
+
+    public ReconnectingThrowableHandler(
+            final @NotNull HookingConfiguration config,
+            final @NotNull BukkitTaskScheduler taskScheduler,
+            final @NotNull Logger log,
+            final @NotNull Callable<Boolean> reconnect,
+            final @NotNull Callable<Boolean> testConnection) {
+        this.isEnabledSupplier = () -> config.getBoolean(DO_RECONNECT_PATH, DO_RECONNECT_DEFAULT);
+        this.log = log;
+        updateIntervals(config);
+        config.subscribeOnRefreshed(this::updateIntervals);
+        this.reconnectTask = new ReconnectTask(intervalsQueue, taskScheduler, log, reconnect, testConnection);
+    }
+
+    @Override public void handle(final @NotNull Throwable th) {
+        if (!isEnabledSupplier.get()) {
+            log.info("Auto reconnect was disabled, skipping reconnection task setup.");
+            reportException(th);
+            return;
+        }
+        if (isConnectionFailureMessage(th, th.getMessage().toLowerCase()))
+            reconnectTask.startIfNotRunning();
+        else
+            reportException(th);
+    }
+
+    private void reportException(final @NotNull Throwable th) {
+        log.warning(format("Exception on db query {0}: {1}.", th.getClass(), th.getMessage()));
+    }
+
+    private boolean isConnectionFailureMessage(final Throwable th, final String message) {
+        return th instanceof CommunicationsException
+                || message.contains("communications link failure")
+                /* will be funny if the message was like "connection established, file closed" :clown: */
+                || (message.contains("connection") && message.contains("closed"));
+    }
+
+    private void updateIntervals(final Configuration configuration) {
+        List<String> strIntervals = configuration.getList(RECONNECTION_INTERVALS_PATH);
+        List<Long> intervals = new ArrayList<>(strIntervals.size());
+        for (final String strInterval : strIntervals) {
+            try {
+                intervals.add(Long.parseLong(strInterval));
+            } catch (final NumberFormatException nfe) {
+                log.warning(format("Invalid interval {0}->{1}", nfe.getClass().getSimpleName(), nfe.getMessage()));
+            }
+        }
+        this.intervalsQueue.resetIntervals(intervals, DEFAULT_INTERVALS_TIME_UNIT);
+    }
+}

--- a/src/main/java/ru/soknight/peconomy/task/BukkitTaskScheduler.java
+++ b/src/main/java/ru/soknight/peconomy/task/BukkitTaskScheduler.java
@@ -1,0 +1,18 @@
+package ru.soknight.peconomy.task;
+
+import lombok.RequiredArgsConstructor;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+public final class BukkitTaskScheduler {
+    private final Plugin plugin;
+
+    public @Nullable BukkitTask asyncLater(final @NotNull Runnable task, final long delay, final @NotNull TimeUnit unit) {
+        return delay >= 0 ? plugin.getServer().getScheduler().runTaskLaterAsynchronously(plugin, task, unit.toSeconds(delay) * 20L) : null;
+    }
+}

--- a/src/main/java/ru/soknight/peconomy/task/ReconnectTask.java
+++ b/src/main/java/ru/soknight/peconomy/task/ReconnectTask.java
@@ -1,0 +1,59 @@
+package ru.soknight.peconomy.task;
+
+import lombok.RequiredArgsConstructor;
+import org.bukkit.scheduler.BukkitTask;
+import ru.soknight.peconomy.configuration.IntervalsQueue;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static java.text.MessageFormat.format;
+
+@RequiredArgsConstructor
+public final class ReconnectTask {
+    private final IntervalsQueue intervalsQueue;
+    private final BukkitTaskScheduler taskScheduler;
+    private final Logger log;
+    private final Callable<Boolean> reconnect;
+    private final Callable<Boolean> testConnection;
+    private BukkitTask bukkitTask;
+
+    public void startIfNotRunning() {
+        if (bukkitTask != null && !bukkitTask.isCancelled())
+            return; /* ignore as we are already running */
+        log.info("Apparently we lost database connection, scheduling reconnection task...");
+        bukkitTask = taskScheduler.asyncLater(this::reconnectOrScheduleNext, intervalsQueue.nextOrLast(), intervalsQueue.intervalTimeUnit());
+    }
+
+    private void reconnectOrScheduleNext() {
+        boolean isReconnected = false;
+        try {
+            /* reconnect call is unnecessary as long as database credentials don't update */
+            isReconnected = reconnect.call() && testConnection.call();
+        } catch (final Exception reconnectException) {
+            log.warning(format("Could not reconnect {0}->{1}", reconnectException.getClass().getSimpleName(),
+                    reconnectException.getMessage().split("\n+")[0]));
+        }
+        if (!isReconnected) {
+            final long nextAttemptIn = intervalsQueue.nextOrLast();
+            final TimeUnit delayUnit = intervalsQueue.intervalTimeUnit();
+            bukkitTask = taskScheduler.asyncLater(this::reconnectOrScheduleNext, nextAttemptIn, delayUnit);
+            log.warning(format("Could not reconnect, scheduled next attempt in {0} {1}", nextAttemptIn, delayUnit));
+        } else {
+            log.info("Successfully reconnected.");
+            cancel();
+        }
+    }
+
+    private void cancel() {
+        /* #cancel() method can go public later on if needed for a reconnect command
+         * although then comes a good question on how they'd obtain this object
+         * sounds more like a future me problem */
+        if (bukkitTask != null) {
+            if (!bukkitTask.isCancelled())
+                bukkitTask.cancel();
+            bukkitTask = null;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,6 +29,21 @@
 #
 # Configuration of database connection
 database:
+  reconnect:
+    #  Whether the plugin should try reconnecting to the database
+    # after discovering a connection loose.
+    auto: true
+    #  Time intervals to perform reconnection task.
+    # The reconnection task will be run sequentially with the said
+    # intervals, the last one will be repeated indefinitely.
+    #
+    #  For example, your intervals are [ 1, 2, 3, 60 ], the plugin
+    # will try to reconnect, if it fails the next attempts will
+    # appear in 1, then in 2 and 3 seconds. If 1, 2 and 3 intervals
+    # fail, all the next attempts will only use the last 60 sec.
+    # interval.
+    intervals-in-seconds: [0, 5, 5, 5, 30, 60, 120]
+
   # The type of used database
   # Supported types: [mysql, sqlite, postgresql]
   type: sqlite

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,21 +29,6 @@
 #
 # Configuration of database connection
 database:
-  reconnect:
-    #  Whether the plugin should try reconnecting to the database
-    # after discovering a connection loose.
-    auto: true
-    #  Time intervals to perform reconnection task.
-    # The reconnection task will be run sequentially with the said
-    # intervals, the last one will be repeated indefinitely.
-    #
-    #  For example, your intervals are [ 1, 2, 3, 60 ], the plugin
-    # will try to reconnect, if it fails the next attempts will
-    # appear in 1, then in 2 and 3 seconds. If 1, 2 and 3 intervals
-    # fail, all the next attempts will only use the last 60 sec.
-    # interval.
-    intervals-in-seconds: [0, 5, 5, 5, 30, 60, 120]
-
   # The type of used database
   # Supported types: [mysql, sqlite, postgresql]
   type: sqlite
@@ -73,6 +58,21 @@ database:
   # SQLite connection configuration
   sqlite:
     file: database.db
+
+  reconnect:
+    #  Whether the plugin should try reconnecting to the database
+    # after discovering a connection loose.
+    auto: true
+    #  Time intervals to perform reconnection task.
+    # The reconnection task will be run sequentially with the said
+    # intervals, the last one will be repeated indefinitely.
+    #
+    #  For example, your intervals are [ 1, 2, 3, 60 ], the plugin
+    # will try to reconnect, if it fails the next attempts will
+    # appear in 1, then in 2 and 3 seconds. If 1, 2 and 3 intervals
+    # fail, all the next attempts will only use the last 60 sec.
+    # interval.
+    intervals-in-seconds: [0, 5, 5, 5, 30, 60, 120]
 
 # Configuration of messages
 messages:


### PR DESCRIPTION
Addresses the https://github.com/SoKnight/PEconomy/issues/11 issue fixing `wait_timeout` problem.

The implementation here will only launch reconnection task if either the exception is an instance of `CommunicationsException` or the exception message contains `"communications link failure"` or `connection` with `closed`.

It is not guaranteed to work with postgres tho, haven't tested it yet.